### PR TITLE
Remove dd-serverless-azure-java-agent Jars from GitHub Releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -72,8 +72,6 @@ jobs:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - run: |
           cp target/dd-serverless-compat-java-agent-${{ env.PACKAGE_VERSION }}.jar target/dd-serverless-compat-java-agent.jar
-          cp target/dd-serverless-compat-java-agent-${{ env.PACKAGE_VERSION }}.jar target/dd-serverless-azure-java-agent-${{ env.PACKAGE_VERSION }}.jar
-          cp target/dd-serverless-compat-java-agent-${{ env.PACKAGE_VERSION }}.jar target/dd-serverless-azure-java-agent.jar
       - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           body: "Uses [${{ env.SERVERLESS_COMPAT_VERSION }}](https://github.com/DataDog/libdatadog/releases/tag/sls-${{ env.SERVERLESS_COMPAT_VERSION }}) of the Serverless Compatibility Layer binary."
@@ -84,8 +82,6 @@ jobs:
           files: |
             target/dd-serverless-compat-java-agent-${{ env.PACKAGE_VERSION }}.jar
             target/dd-serverless-compat-java-agent.jar
-            target/dd-serverless-azure-java-agent-${{ env.PACKAGE_VERSION }}.jar
-            target/dd-serverless-azure-java-agent.jar
       - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           name: Latest
@@ -93,4 +89,3 @@ jobs:
           body: "This release tracks the latest version available, currently **${{ env.PACKAGE_VERSION }}**."
           files: |
             target/dd-serverless-compat-java-agent.jar
-            target/dd-serverless-azure-java-agent.jar

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 
 # Maven
 target
+settings.xml

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Follow the instructions in the `dd-trace-java` repo to set up your Java environm
 
 ## Building the project
 
-Build the Datadog Serverless Compatibility Layer from [libdatadog](https://github.com/DataDog/libdatadog) and add the binaries, `datadog-serverless-compat` and `datadog-serverless-compat.exe`, to `src/main/resources`.
+Build the Datadog Serverless Compatibility Layer from [libdatadog](https://github.com/DataDog/libdatadog) and add the binaries, `datadog-serverless-compat` and `datadog-serverless-compat.exe`, to `bin`.
 
 To build the project run:
 ```


### PR DESCRIPTION
### What does this PR do?

* Removes `dd-serverless-azure-java-agent` jar files from GitHub Releases in favor of `dd-serverless-compat-java-agent` jars
* Adds `settings.xml` to `.gitignore` to allow for local publishing to staging
* Update readme to reflect correct directory for binaries

### Motivation

Rename to Serverless Compatibility Layer means that `dd-serverless-azure-java-agent` jars are renamed to `dd-serverless-compat-java-agent`.

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
