### PR TITLE
Pass serverless compat version to binary via environment variable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,9 @@
                                     implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Premain-Class>com.datadog.ServerlessCompatAgent</Premain-Class>
+                                        <Implementation-Title>${project.artifactId}</Implementation-Title>
+                                        <Implementation-Version>${project.version}</Implementation-Version>
+                                        <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>

--- a/src/main/java/com/datadog/ServerlessCompatAgent.java
+++ b/src/main/java/com/datadog/ServerlessCompatAgent.java
@@ -23,6 +23,20 @@ public class ServerlessCompatAgent {
         return os.contains("linux");
     }
 
+    public static String setPackageVersion() {
+        String packageVersion;
+
+        try {
+            packageVersion = ServerlessCompatAgent.class.getPackage().getImplementationVersion();
+        }
+        catch (Exception e) {
+            log.error("Unable to identify package version", e);
+            packageVersion = "unknown";
+        }
+
+        return packageVersion == null ? "unknown" : packageVersion;
+    }
+
     public static void premain(String agentArgs, Instrumentation instrumentation) {
         final String fileName;
         final String tempDirPath;
@@ -66,7 +80,11 @@ public class ServerlessCompatAgent {
                 executableFile = userExecutableFile;
             }
 
+            String packageVersion = setPackageVersion();
+            log.debug("Found package version {}", packageVersion);
+
             ProcessBuilder processBuilder = new ProcessBuilder(executableFile.getAbsolutePath());
+            processBuilder.environment().put("DD_SERVERLESS_COMPAT_VERSION", packageVersion);
             processBuilder.inheritIO();
             processBuilder.start();
         } catch (Exception e) {


### PR DESCRIPTION
### What does this PR do?

Set `DD_SERVERLESS_COMPAT_VERSION` to the currently installed package version.

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-6326

### Additional Notes

Previously the version was set to the binary version. Since these packages were introduced it would be useful for troubleshooting to track the package versions installed by users. Since a specific version of the binary is packaged in each package version we can still trace back the binary version via the package version.

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
