### PR TITLE
Check if environment is supported by serverless compat

### DIFF
--- a/src/main/java/com/datadog/ServerlessCompatAgent.java
+++ b/src/main/java/com/datadog/ServerlessCompatAgent.java
@@ -7,8 +7,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+enum CloudEnvironment {
+    AZURE_FUNCTION,
+    AZURE_SPRING_APP,
+    GOOGLE_CLOUD_RUN_FUNCTION_1ST_GEN,
+    GOOGLE_CLOUD_RUN_FUNCTION_2ND_GEN,
+    UNKNOWN
+}
 
 public class ServerlessCompatAgent {
     private static final Logger log = LoggerFactory.getLogger(ServerlessCompatAgent.class);
@@ -23,7 +32,41 @@ public class ServerlessCompatAgent {
         return os.contains("linux");
     }
 
+    public static CloudEnvironment getEnvironment() {
+        Map<String, String> env = System.getenv();
+
+        if (env.get("FUNCTIONS_EXTENSION_VERSION") != null &&
+                env.get("FUNCTIONS_WORKER_RUNTIME") != null) {
+            return CloudEnvironment.AZURE_FUNCTION;
+        }
+
+        if (env.get("ASCSVCRT_SPRING__APPLICATION__NAME") != null) {
+            return CloudEnvironment.AZURE_SPRING_APP;
+        }
+
+        if (env.get("FUNCTION_NAME") != null &&
+                env.get("GCP_PROJECT") != null) {
+            return CloudEnvironment.GOOGLE_CLOUD_RUN_FUNCTION_1ST_GEN;
+        }
+
+        if (env.get("K_SERVICE") != null &&
+                env.get("FUNCTION_TARGET") != null) {
+            return CloudEnvironment.GOOGLE_CLOUD_RUN_FUNCTION_2ND_GEN;
+        }
+
+        return CloudEnvironment.UNKNOWN;
+    }
+
     public static void premain(String agentArgs, Instrumentation instrumentation) {
+        CloudEnvironment environment = getEnvironment();
+        log.debug("Environment detected: {}", environment);
+
+        if (environment == CloudEnvironment.UNKNOWN) {
+            log.error("{} environment detected, will not start the Datadog Serverless Compatibility Layer",
+                    environment);
+            return;
+        }
+
         final String fileName;
         final String tempDirPath;
 

--- a/src/main/java/com/datadog/ServerlessCompatAgent.java
+++ b/src/main/java/com/datadog/ServerlessCompatAgent.java
@@ -15,7 +15,6 @@ enum CloudEnvironment {
     AZURE_FUNCTION,
     AZURE_SPRING_APP,
     GOOGLE_CLOUD_RUN_FUNCTION_1ST_GEN,
-    GOOGLE_CLOUD_RUN_FUNCTION_2ND_GEN,
     UNKNOWN
 }
 
@@ -47,11 +46,6 @@ public class ServerlessCompatAgent {
         if (env.get("FUNCTION_NAME") != null &&
                 env.get("GCP_PROJECT") != null) {
             return CloudEnvironment.GOOGLE_CLOUD_RUN_FUNCTION_1ST_GEN;
-        }
-
-        if (env.get("K_SERVICE") != null &&
-                env.get("FUNCTION_TARGET") != null) {
-            return CloudEnvironment.GOOGLE_CLOUD_RUN_FUNCTION_2ND_GEN;
         }
 
         return CloudEnvironment.UNKNOWN;


### PR DESCRIPTION
### What does this PR do?

Check if the Serverless Compatibility Layer is attempting to be started in one of the below environments.

* Azure Function
* Azure Spring App
* Google Cloud Function (gen1)
* ~Google Cloud Function (gen2)~

### Motivation

Only allow Serverless Compat to run in explicitly supported environments.

https://datadoghq.atlassian.net/browse/SVLS-6448

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

Deployed to self monitoring for each environment and confirmed that the jar starts the Serverless Compat process.
