### PR TITLE
chore: use binaries from serverless-components in release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
       - id: serverless-compat-binary
         run: |
           RESPONSE=$(curl -s "https://api.github.com/repos/datadog/serverless-components/releases")
-          SERVERLESS_COMPAT_VERSION=$(echo "$RESPONSE" | jq -r --arg pattern "test\/datadog-serverless-compat\/v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
+          SERVERLESS_COMPAT_VERSION=$(echo "$RESPONSE" | jq -r --arg pattern "datadog-serverless-compat\/v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
 
           echo "Using version ${SERVERLESS_COMPAT_VERSION} of Serverless Compatibility Layer binary"
           echo "serverless-compat-version=$(echo "$SERVERLESS_COMPAT_VERSION" | jq -rR 'ltrimstr("sls-")')" >> "$GITHUB_OUTPUT"
@@ -40,6 +40,31 @@ jobs:
         with:
           name: bin
           path: bin
+  build:
+    needs: [downloadbinaries]
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
+      SONATYPE_USER: ${{secrets.SONATYPE_USER}}
+      SONATYPE_PASS: ${{secrets.SONATYPE_PASS}}
+      GPG_PASSPHRASE: ${{secrets.GPG_PASSPHRASE}}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      - uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
+        with:
+          java-version: "21"
+          distribution: "zulu"
+          server-id: "nexus"
+          server-username: "SONATYPE_USER"
+          server-password: "SONATYPE_PASS"
+          gpg-private-key: ${{secrets.GPG_SIGNING_KEY}}
+          gpg-passphrase: "GPG_PASSPHRASE"
+      - run: mvn -P release clean package
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: build
+          path: target/dd-serverless-compat-java-agent-${{ env.PACKAGE_VERSION }}.jar
   publish:
     if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     needs: [downloadbinaries]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,16 @@
 name: Build and Release the Serverless Compat Java Agent
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      publish-package:
+        description: "Build or Build and Publish?"
+        required: true
+        type: choice
+        default: "Build"
+        options:
+          - "Build"
+          - "Build and Publish"
 
 permissions: {}
 
@@ -18,23 +28,20 @@ jobs:
           echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
       - id: serverless-compat-binary
         run: |
-          LIBDATADOG_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/libdatadog/releases")
-          SERVERLESS_COMPAT_VERSION=$(echo "$LIBDATADOG_RESPONSE" | jq -r --arg pattern "sls-v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
+          RESPONSE=$(curl -s "https://api.github.com/repos/datadog/serverless-components/releases")
+          SERVERLESS_COMPAT_VERSION=$(echo "$RESPONSE" | jq -r --arg pattern "test\/datadog-serverless-compat\/v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
 
           echo "Using version ${SERVERLESS_COMPAT_VERSION} of Serverless Compatibility Layer binary"
           echo "serverless-compat-version=$(echo "$SERVERLESS_COMPAT_VERSION" | jq -rR 'ltrimstr("sls-")')" >> "$GITHUB_OUTPUT"
 
-          curl --output-dir ./temp/ --create-dirs -O -s -L "https://github.com/DataDog/libdatadog/releases/download/${SERVERLESS_COMPAT_VERSION}/datadog-serverless-agent.zip"
-          unzip ./temp/datadog-serverless-agent.zip -d ./temp/datadog-serverless-agent
-
-          mkdir -p bin/linux-amd64 bin/windows-amd64
-          cp ./temp/datadog-serverless-agent/datadog-serverless-agent-linux-amd64/datadog-serverless-trace-mini-agent bin/linux-amd64/datadog-serverless-compat
-          cp ./temp/datadog-serverless-agent/datadog-serverless-agent-windows-amd64/datadog-serverless-trace-mini-agent.exe bin/windows-amd64/datadog-serverless-compat.exe
+          curl --output-dir ./temp/ --create-dirs -O -s -L "https://github.com/DataDog/serverless-components/releases/download/${SERVERLESS_COMPAT_VERSION}/datadog-serverless-compat.zip"
+          unzip ./temp/datadog-serverless-compat.zip -d ./
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: bin
           path: bin
   publish:
+    if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     needs: [downloadbinaries]
     runs-on: ubuntu-latest
     env:
@@ -60,6 +67,7 @@ jobs:
           name: target
           path: target/dd-serverless-compat-java-agent-${{ env.PACKAGE_VERSION }}.jar
   release:
+    if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     needs: [downloadbinaries, publish]
     runs-on: ubuntu-latest
     permissions:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datadoghq</groupId>
     <artifactId>dd-serverless-compat-java-agent</artifactId>
-    <version>0.9.0</version>
+    <version>0.9.1</version>
     <packaging>jar</packaging>
     <name>Datadog Serverless Compatibility Layer</name>
     <description>Datadog Serverless Compatibility Layer for Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datadoghq</groupId>
     <artifactId>dd-serverless-compat-java-agent</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.0</version>
     <packaging>jar</packaging>
     <name>Datadog Serverless Compatibility Layer</name>
     <description>Datadog Serverless Compatibility Layer for Java</description>


### PR DESCRIPTION
### What does this PR do?

- Use binaries from serverless-components in package
- Add option to only build (and not publish) package for testing

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-6786

### Additional Notes

### Describe how to test/QA your changes

Installed package created by CI and deployed to Azure Functions
