### PR TITLE
chore: use mvn versions:set to set package version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,12 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - id: package
         run: |
-          PACKAGE_VERSION=$(awk -F '[<>]' '/<version>/{print $3; exit}' pom.xml)
+          if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag format: $GITHUB_REF, must be in the form vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+          PACKAGE_VERSION="${GITHUB_REF#refs/tags/v}"
+
           echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
       - id: serverless-compat-binary
         run: |
@@ -45,9 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
-      SONATYPE_USER: ${{secrets.SONATYPE_USER}}
-      SONATYPE_PASS: ${{secrets.SONATYPE_PASS}}
-      GPG_PASSPHRASE: ${{secrets.GPG_PASSPHRASE}}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -55,11 +57,7 @@ jobs:
         with:
           java-version: "21"
           distribution: "zulu"
-          server-id: "nexus"
-          server-username: "SONATYPE_USER"
-          server-password: "SONATYPE_PASS"
-          gpg-private-key: ${{secrets.GPG_SIGNING_KEY}}
-          gpg-passphrase: "GPG_PASSPHRASE"
+      - run: mvn versions:set -DnewVersion=${{ env.PACKAGE_VERSION }}
       - run: mvn -P release clean package
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
@@ -86,6 +84,7 @@ jobs:
           server-password: "SONATYPE_PASS"
           gpg-private-key: ${{secrets.GPG_SIGNING_KEY}}
           gpg-passphrase: "GPG_PASSPHRASE"
+      - run: mvn versions:set -DnewVersion=${{ env.PACKAGE_VERSION }}
       - run: mvn -P release clean deploy
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 # Maven
 target
 settings.xml
+pom.xml.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datadoghq</groupId>
     <artifactId>dd-serverless-compat-java-agent</artifactId>
-    <version>0.9.0</version>
+    <version>0.0.0</version>
     <packaging>jar</packaging>
     <name>Datadog Serverless Compatibility Layer</name>
     <description>Datadog Serverless Compatibility Layer for Java</description>


### PR DESCRIPTION
### What does this PR do?

Use `mvn versions:set` in Github release workflow to set the version instead of hardcoding the version in `pom.xml`.

### Motivation

Remove a manual step during the release process.

### Additional Notes

- Package version is read from the Git tag used for the release
- Removed unnecessary credentials during build job as they are only needed on the publish job

### Describe how to test/QA your changes

Tested in a separate repo to avoid the creation of test tags and test releases in this repo.

- Validated that jars created during the build step have a version which matches the tag the Github workflow ran against
- Validated that the workflow stops if the tag does not match the expected format `vMAJOR.MINOR.PATCH`
