### PR TITLE
[SVLS-6337] Don't spawn agent process if DD_AZURE_RESOURCE_GROUP not set for Azure flex consumption functions

### DIFF
--- a/src/main/java/com/datadog/ServerlessCompatAgent.java
+++ b/src/main/java/com/datadog/ServerlessCompatAgent.java
@@ -64,6 +64,10 @@ public class ServerlessCompatAgent {
         return packageVersion == null ? "unknown" : packageVersion;
     }
 
+    public static boolean isAzureFlexWithoutDDAzureResourceGroup() {
+        return System.getenv("WEBSITE_SKU") == "FlexConsumption" && System.getenv("DD_AZURE_RESOURCE_GROUP") == null;
+    }
+
     public static void premain(String agentArgs, Instrumentation instrumentation) {
         CloudEnvironment environment = getEnvironment();
         log.debug("Environment detected: {}", environment);
@@ -89,6 +93,14 @@ public class ServerlessCompatAgent {
             log.error("Unsupported operating system {}", os);
             return;
         }
+
+        // Check for Azure Flex Consumption functions that don't have the DD_AZURE_RESOURCE_GROUP environment variable set
+        if (environment == CloudEnvironment.AZURE_FUNCTION) {
+            if isAzureFlexWithoutDDAzureResourceGroup() {
+                log.error("Azure function detected on flex consumption plan without DD_AZURE_RESOURCE_GROUP set. Please set the DD_AZURE_RESOURCE_GROUP environment variable to your resource group name in Azure app settings. Shutting down Datadog Serverless Compatibility Layer.");
+                return;
+            }
+        } 
 
         try (InputStream inputStream = ServerlessCompatAgent.class.getClassLoader()
                 .getResourceAsStream(fileName)) {

--- a/src/main/java/com/datadog/ServerlessCompatAgent.java
+++ b/src/main/java/com/datadog/ServerlessCompatAgent.java
@@ -65,7 +65,7 @@ public class ServerlessCompatAgent {
     }
 
     public static boolean isAzureFlexWithoutDDAzureResourceGroup() {
-        return System.getenv("WEBSITE_SKU") == "FlexConsumption" && System.getenv("DD_AZURE_RESOURCE_GROUP") == null;
+        return "FlexConsumption".equals(System.getenv("WEBSITE_SKU")) && System.getenv("DD_AZURE_RESOURCE_GROUP") == null;
     }
 
     public static void premain(String agentArgs, Instrumentation instrumentation) {
@@ -96,7 +96,7 @@ public class ServerlessCompatAgent {
 
         // Check for Azure Flex Consumption functions that don't have the DD_AZURE_RESOURCE_GROUP environment variable set
         if (environment == CloudEnvironment.AZURE_FUNCTION) {
-            if isAzureFlexWithoutDDAzureResourceGroup() {
+            if (isAzureFlexWithoutDDAzureResourceGroup()) {
                 log.error("Azure function detected on flex consumption plan without DD_AZURE_RESOURCE_GROUP set. Please set the DD_AZURE_RESOURCE_GROUP environment variable to your resource group name in Azure app settings. Shutting down Datadog Serverless Compatibility Layer.");
                 return;
             }

--- a/src/main/java/com/datadog/ServerlessCompatAgent.java
+++ b/src/main/java/com/datadog/ServerlessCompatAgent.java
@@ -95,11 +95,9 @@ public class ServerlessCompatAgent {
         }
 
         // Check for Azure Flex Consumption functions that don't have the DD_AZURE_RESOURCE_GROUP environment variable set
-        if (environment == CloudEnvironment.AZURE_FUNCTION) {
-            if (isAzureFlexWithoutDDAzureResourceGroup()) {
-                log.error("Azure function detected on flex consumption plan without DD_AZURE_RESOURCE_GROUP set. Please set the DD_AZURE_RESOURCE_GROUP environment variable to your resource group name in Azure app settings. Shutting down Datadog Serverless Compatibility Layer.");
-                return;
-            }
+        if (environment == CloudEnvironment.AZURE_FUNCTION && isAzureFlexWithoutDDAzureResourceGroup()) {
+            log.error("Azure function detected on flex consumption plan without DD_AZURE_RESOURCE_GROUP set. Please set the DD_AZURE_RESOURCE_GROUP environment variable to your resource group name in Azure app settings. Shutting down Datadog Serverless Compatibility Layer.");
+            return;
         } 
 
         try (InputStream inputStream = ServerlessCompatAgent.class.getClassLoader()


### PR DESCRIPTION
### What does this PR do?
Adds a check to see if we are in an Azure function that is on the flex consumption plan and doesn't have the `DD_AZURE_RESOURCE_GROUP` env var set. If so, return before the agent process can be spawned.
  - We updated the libdatadog [Azure metadata detection logic](https://github.com/DataDog/libdatadog/pull/1241) to check for the resource group similarly, as well as [serverless-components/datadog-trace-agent](https://github.com/DataDog/serverless-components/pull/39) to shut down the trace agent if the resource group can't be determined

### Motivation
- Currently the `aas.resource.group` span attribute for functions on flex consumption plans is set incorrectly in Datadog - they're all set to "flex"
  - This is important to fix because `aas.resource.id` is built using `aas.resource.group`, and the resource id is used in billing, which needs to be accurate
  - We had to figure out what to do if a customer who is using Datadog to monitor their Azure function on a flex consumption plan doesn't set the `DD_AZURE_RESOURCE_GROUP` env var. Rather than handling that in `libdatadog`, we decided to do it at a higher level in the trace agent to inform the customer of the error while shutting down the trace agent gracefully and preventing any traces from being sent to Datadog, as well as adding this in the serverless-compat layers to have defense in depth

[Jira Ticket](https://datadoghq.atlassian.net/browse/SVLS-6337?atlOrigin=eyJpIjoiNzhhNTkwOWFmODFhNGZjZmJhZDc1OGE2ZjJkOTg0NjYiLCJwIjoiaiJ9)

### Describe how to test/QA your changes
1. Clone [serverless-components](https://github.com/DataDog/serverless-components/tree/main) and update the commit hash in [datadog-trace-agent/Cargo.toml
](https://github.com/DataDog/serverless-components/blob/main/crates/datadog-trace-agent/Cargo.toml) everywhere that `libdatadog` is used to the most recent commit hash of the PR in [libdatadog](https://github.com/DataDog/libdatadog/pull/1241) (currently `d1b35ef21fff3c4588073504905081c8923bbc4b`)
2. Follow the instructions in the [Serverless Compatability Layer docs](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2977497119/Serverless+Compatibility+Layer) to build the Rust binary
3. Deploy an Azure function on flex consumption plan using [the terraform tool](https://github.com/DataDog/serverless-init-self-monitoring/tree/main/old-self-monitoring/azure/functions), setting `use_serverless_compat_local_path` to true and making sure the built binary is in your `python` folder
4. Hit an endpoint in your function or wait a minute for the invoker to invoke your function and check the Datadog traces for your function. Without the `DD_AZURE_RESOURCE_GROUP` env var, you should see no traces
5. Go to Settings > Environment Variables in the Azure Portal for your function and add `DD_AZURE_RESOURCE_GROUP` as an environment variable with your resource group. Repeat step 4, you should see the correct resource group in the `resource.group` span attribute!
<img width="1736" height="1318" alt="image" src="https://github.com/user-attachments/assets/eb5227a7-004f-4f76-b481-20604dea6178" />
