### PR TITLE
fix: surface logs and map datadog log level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,20 +147,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.0</version>
-                <configuration>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>module-info.class</exclude>
-                                <exclude>META-INF/*</exclude>
-                                <exclude>META-INF/versions/**</exclude>
-                                <exclude>META-INF/services/**</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -168,6 +154,25 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <!--
+                                        Remove some cruft from the final jar.
+                                        These patterns should NOT include **/META-INF/maven/**/pom.properties, which is
+                                        used to report our own dependencies, but we should remove the top-level metadata
+                                        of vendored packages because those could trigger unwanted framework checks.
+                                    -->
+                                    <excludes>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/*</exclude>
+                                        <exclude>META-INF/versions/**</exclude>
+                                        <exclude>META-INF/maven/org.slf4j/**</exclude>
+                                        <exclude>META-INF/maven/**/pom.xml</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <relocations>
                                 <relocation>
                                     <pattern>org.slf4j</pattern>
@@ -175,6 +180,8 @@
                                 </relocation>
                             </relocations>
                             <transformers>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,20 @@
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.16</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>6.0.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>6.0.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -143,6 +157,7 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -195,6 +210,12 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/datadog/ServerlessCompatAgent.java
+++ b/src/main/java/com/datadog/ServerlessCompatAgent.java
@@ -19,7 +19,27 @@ enum CloudEnvironment {
 }
 
 public class ServerlessCompatAgent {
-    private static final Logger log = LoggerFactory.getLogger(ServerlessCompatAgent.class);
+    private static String mapDdLogLevelToSlf4jLogLevel(String ddLogLevel) {
+        switch (ddLogLevel) {
+            case "CRITICAL":
+                return "ERROR";
+            default:
+                return ddLogLevel;
+        }
+    }
+
+    private static final Logger log;
+
+    static {
+        String ddLogLevel = System.getenv().getOrDefault("DD_LOG_LEVEL", "INFO").toUpperCase();
+        if (ddLogLevel.equals("OFF")) {
+            log = org.slf4j.helpers.NOPLogger.NOP_LOGGER;
+        } else {
+            System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", mapDdLogLevelToSlf4jLogLevel(ddLogLevel));
+            log = LoggerFactory.getLogger(ServerlessCompatAgent.class);
+        }
+    }
+
     private static final String os = System.getProperty("os.name").toLowerCase();
     private static final String binaryPath = System.getenv("DD_SERVERLESS_COMPAT_PATH");
 

--- a/src/main/java/com/datadog/ServerlessCompatAgent.java
+++ b/src/main/java/com/datadog/ServerlessCompatAgent.java
@@ -85,7 +85,8 @@ public class ServerlessCompatAgent {
     }
 
     public static boolean isAzureFlexWithoutDDAzureResourceGroup() {
-        return "FlexConsumption".equals(System.getenv("WEBSITE_SKU")) && System.getenv("DD_AZURE_RESOURCE_GROUP") == null;
+        return "FlexConsumption".equals(System.getenv("WEBSITE_SKU"))
+                && System.getenv("DD_AZURE_RESOURCE_GROUP") == null;
     }
 
     public static void premain(String agentArgs, Instrumentation instrumentation) {
@@ -114,11 +115,13 @@ public class ServerlessCompatAgent {
             return;
         }
 
-        // Check for Azure Flex Consumption functions that don't have the DD_AZURE_RESOURCE_GROUP environment variable set
+        // Check for Azure Flex Consumption functions that don't have the
+        // DD_AZURE_RESOURCE_GROUP environment variable set
         if (environment == CloudEnvironment.AZURE_FUNCTION && isAzureFlexWithoutDDAzureResourceGroup()) {
-            log.error("Azure function detected on flex consumption plan without DD_AZURE_RESOURCE_GROUP set. Please set the DD_AZURE_RESOURCE_GROUP environment variable to your resource group name in Azure app settings. Shutting down Datadog Serverless Compatibility Layer.");
+            log.error(
+                    "Azure function detected on flex consumption plan without DD_AZURE_RESOURCE_GROUP set. Please set the DD_AZURE_RESOURCE_GROUP environment variable to your resource group name in Azure app settings. Shutting down Datadog Serverless Compatibility Layer.");
             return;
-        } 
+        }
 
         try (InputStream inputStream = ServerlessCompatAgent.class.getClassLoader()
                 .getResourceAsStream(fileName)) {

--- a/src/main/java/com/datadog/ServerlessCompatAgent.java
+++ b/src/main/java/com/datadog/ServerlessCompatAgent.java
@@ -10,6 +10,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
 
 enum CloudEnvironment {
     AZURE_FUNCTION,
@@ -19,20 +20,22 @@ enum CloudEnvironment {
 }
 
 public class ServerlessCompatAgent {
-    private static String mapDdLogLevelToSlf4jLogLevel(String ddLogLevel) {
-        return "CRITICAL".equals(ddLogLevel) ? "ERROR" : ddLogLevel;
+    private static final String ddLogLevel = System.getenv().getOrDefault("DD_LOG_LEVEL", "INFO").toUpperCase();
+
+    private static final Logger log = initLogger(ddLogLevel);
+
+    private static Logger initLogger(String logLevel) {
+        if ("OFF".equals(logLevel)) {
+            return NOPLogger.NOP_LOGGER;
+        } else {
+            System.setProperty("org.slf4j.simpleLogger.defaultLogLevel",
+                    mapDdLogLevelToSlf4jLogLevel(logLevel));
+            return LoggerFactory.getLogger(ServerlessCompatAgent.class);
+        }
     }
 
-    private static final Logger log;
-
-    static {
-        String ddLogLevel = System.getenv().getOrDefault("DD_LOG_LEVEL", "INFO").toUpperCase();
-        if (ddLogLevel.equals("OFF")) {
-            log = org.slf4j.helpers.NOPLogger.NOP_LOGGER;
-        } else {
-            System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", mapDdLogLevelToSlf4jLogLevel(ddLogLevel));
-            log = LoggerFactory.getLogger(ServerlessCompatAgent.class);
-        }
+    private static String mapDdLogLevelToSlf4jLogLevel(String ddLogLevel) {
+        return "CRITICAL".equals(ddLogLevel) ? "ERROR" : ddLogLevel;
     }
 
     private static final String os = System.getProperty("os.name").toLowerCase();

--- a/src/main/java/com/datadog/ServerlessCompatAgent.java
+++ b/src/main/java/com/datadog/ServerlessCompatAgent.java
@@ -20,12 +20,7 @@ enum CloudEnvironment {
 
 public class ServerlessCompatAgent {
     private static String mapDdLogLevelToSlf4jLogLevel(String ddLogLevel) {
-        switch (ddLogLevel) {
-            case "CRITICAL":
-                return "ERROR";
-            default:
-                return ddLogLevel;
-        }
+        return "CRITICAL".equals(ddLogLevel) ? "ERROR" : ddLogLevel;
     }
 
     private static final Logger log;

--- a/src/test/java/test.java
+++ b/src/test/java/test.java
@@ -1,0 +1,34 @@
+import com.datadog.ServerlessCompatAgent;
+import java.lang.reflect.Method;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.slf4j.Logger;
+import org.slf4j.helpers.NOPLogger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ServerlessCompatAgentTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "TRACE, TRACE",
+            "DEBUG, DEBUG",
+            "INFO, INFO",
+            "WARN, WARN",
+            "ERROR, ERROR",
+            "CRITICAL, ERROR",
+            "OFF, null"
+    })
+    void testInitLogger(String ddLogLevel, String expectedSlf4jLevel) throws Exception {
+        Method initLoggerMethod = ServerlessCompatAgent.class.getDeclaredMethod("initLogger", String.class);
+        initLoggerMethod.setAccessible(true);
+        Logger logger = (Logger) initLoggerMethod.invoke(null, ddLogLevel);
+
+        if ("OFF".equals(ddLogLevel)) {
+            assertTrue(logger instanceof NOPLogger);
+        } else {
+            assertEquals(expectedSlf4jLevel,
+                    System.getProperty("org.slf4j.simpleLogger.defaultLogLevel"));
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- Surface logs from the Serverless Compatibility Layer using the relocated `slf4j` package
- Map `DD_LOG_LEVEL` values to `slf4j` log levels

### Motivation

Logs from the Serverless Compatibility Layer not visible.

https://datadoghq.atlassian.net/browse/SVLS-6147

### Additional Notes

- Mimic exclusions from [dd-java-agent.jar](https://github.com/DataDog/dd-trace-java/blob/c05874d84e0f120b821153ee46a4d438c5c484aa/dd-java-agent/build.gradle#L64-L78)

### Describe how to test/QA your changes

Deployed to self monitoring, set `DD_LOG_LEVEL=debug`.

<img width="597" height="70" alt="Screenshot 2025-11-20 at 10 45 28 AM" src="https://github.com/user-attachments/assets/ae241a1c-be29-4a35-acfd-9b173a7ccc0d" />

