### PR TITLE
fix: update broken link for 1st gen cloud run functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Datadog library for Java to enable tracing and custom metric submission from [Az
 # Getting Started
 
 - [Install Serverless Monitoring for Azure Functions](https://docs.datadoghq.com/serverless/azure_functions/?code-lang=java)
-- [Install Serverless Monitoring for Google Cloud Run Functions (1st gen)](https://docs.datadoghq.com/serverless/google_cloud_run/functions_gen1?code-lang=java)
+- [Install Serverless Monitoring for Google Cloud Run Functions (1st gen)](https://docs.datadoghq.com/serverless/google_cloud_run/functions_1st_gen/?tab=java)


### PR DESCRIPTION
### What does this PR do?

Fixes broken link to Datadog public docs for instrumenting 1st Gen Cloud Run Functions.

### Motivation

<!-- Why is this change needed? Link any related Jira cards here. -->

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
